### PR TITLE
'상세보기'를 링크의 호스트 이름으로 변경

### DIFF
--- a/app/assets/stylesheets/post.css.scss
+++ b/app/assets/stylesheets/post.css.scss
@@ -12,9 +12,18 @@
     }
   }
 }
+
+.post {
+  a.host {
+    font-size: 85%;
+    color: #949494;
+  }
+}
+
 .post-content {
   word-break: break-word;
 }
+
 .post-form {
   margin-top: 50px;
   margin-bottom: 20px;

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,4 +13,13 @@ class Post < ActiveRecord::Base
   def self.latest
     order(created_at: :desc)
   end
+
+  def host
+    if self.link
+      uri = URI(self.link)
+      uri.host
+    else
+      ""
+    end
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -44,7 +44,7 @@
             <!-- panel body -->
             <div class="panel-body">
               <p class="post-content"><%= simple_format(post.content) %></p>
-              <%= link_to "상세보기", post.link, target: "blank" %>
+              <%= link_to post.host, post.link, target: "blank" %>
               <small>
 
                 <span class="pull-right">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -40,11 +40,11 @@
     <% @posts.each do |post| %>
       <div class="row">
         <div class="col-md-6 col-md-offset-3">
-          <div class="panel panel-info" data-collapsed="0">
+          <div class="post panel panel-info" data-collapsed="0">
             <!-- panel body -->
             <div class="panel-body">
               <p class="post-content"><%= simple_format(post.content) %></p>
-              <%= link_to post.host, post.link, target: "blank" %>
+              <%= link_to post.host, post.link, class: 'host', target: "blank" %>
               <small>
 
                 <span class="pull-right">


### PR DESCRIPTION
'상세보기' 링크를 링크의 호스트 명(ex: `www.11st.co.kr`)로 변경했습니다.
동시에 우측에 있는 경과 시간(+작성자 이름)과 CSS를 동일하게 맞췄습니다.

`Post`에 `host`라는 함수를 만들었는데, 사실 이렇게 모델 안에에 뷰와 관련된 코드를 넣는 건 좋지 않습니다.(모델이 너무 커집니다.) 차후에는 데코레이터([Draper](https://github.com/drapergem/draper))를 활용해서 모델을 간결하게 해주도록 하죠. ㅎㅎ
